### PR TITLE
Add ASCII art page using pyfiglet

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from flask import (
     current_app,
 )
 import requests
+import pyfiglet
 from dotenv import load_dotenv
 
 # Attempt to load environment variables from a .env file if present.
@@ -65,6 +66,12 @@ def index() -> str:
     token = os.urandom(16).hex()
     session['csrf_token'] = token
     return render_template('index.html', csrf_token=token)
+
+
+@app.route('/ascii')
+def ascii_art() -> str:
+    art = pyfiglet.figlet_format('Hello, ASCII!')
+    return render_template('ascii.html', art=art)
 
 @app.route('/submit', methods=['POST'])
 def submit() -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 requests
 python-dotenv
+pyfiglet

--- a/templates/ascii.html
+++ b/templates/ascii.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>ASCII Art</title>
+    <style>
+        body {
+            font-family: monospace;
+            background: #ffffff;
+            margin: 20px;
+        }
+        pre {
+            font-size: 16px;
+        }
+    </style>
+</head>
+<body>
+    <pre>{{ art }}</pre>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -69,6 +69,7 @@
             <input type="text" name="text" class="search-box" placeholder="Search" required>
             <div class="buttons">
                 <button type="submit">Search</button>
+                <button type="button" onclick="window.location.href='/ascii'">ASCII Art</button>
             </div>
         </form>
     </div>


### PR DESCRIPTION
## Summary
- Add optional ASCII art showcase powered by pyfiglet
- Expose `/ascii` endpoint and template for rendering artwork
- Link new feature from homepage

## Testing
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement pyfiglet)*
- `python -m py_compile main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688eeae55fbc832bb88651af506fb9f8