### PR TITLE
Replace search with send and style result page

### DIFF
--- a/main.py
+++ b/main.py
@@ -73,8 +73,8 @@ def ascii_art() -> str:
     art = pyfiglet.figlet_format('Hello, ASCII!')
     return render_template('ascii.html', art=art)
 
-@app.route('/submit', methods=['POST'])
-def submit() -> str:
+@app.route('/send', methods=['POST'])
+def send() -> str:
     ip = request.remote_addr or 'unknown'
     check_rate_limit(ip)
 
@@ -94,7 +94,7 @@ def submit() -> str:
             print(response.status_code, response.text)
         except Exception as e:
             print('텔레그램 전송 오류:', str(e))
-    return 'OK'
+    return render_template('result.html', text=text)
 
 if __name__ == '__main__':
     # Default port is 5000. Change to 80 for production if needed.

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Search</title>
+    <title>Send</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -31,7 +31,7 @@
             max-width: 560px;
         }
 
-        .search-box {
+        .send-box {
             width: 100%;
             padding: 10px 20px;
             font-size: 16px;
@@ -63,12 +63,12 @@
 </head>
 <body>
     <div class="container">
-        <div class="logo">MySearch</div>
-        <form action="/submit" method="post">
+        <div class="logo">MySend</div>
+        <form action="/send" method="post">
             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-            <input type="text" name="text" class="search-box" placeholder="Search" required>
+            <input type="text" name="text" class="send-box" placeholder="Send" required>
             <div class="buttons">
-                <button type="submit">Search</button>
+                <button type="submit">Send</button>
                 <button type="button" onclick="window.location.href='/ascii'">ASCII Art</button>
             </div>
         </form>

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Sent</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background: #f0f0f0;
+            margin: 0;
+            height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+
+        .message-box {
+            text-align: center;
+            background: #ffffff;
+            padding: 40px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+
+        .message-box h1 {
+            color: #4285f4;
+            margin-bottom: 20px;
+        }
+
+        .message-box p {
+            color: #333333;
+            margin-bottom: 20px;
+        }
+
+        .back {
+            display: inline-block;
+            padding: 10px 20px;
+            background: #4285f4;
+            color: #ffffff;
+            text-decoration: none;
+            border-radius: 4px;
+        }
+
+        .back:hover {
+            background: #357ae8;
+        }
+    </style>
+</head>
+<body>
+    <div class="message-box">
+        <h1>Message Sent</h1>
+        <p>{{ text }}</p>
+        <a href="/" class="back">Back</a>
+    </div>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- Replace search interface with a send-focused layout
- Handle form submissions via new `/send` route and show a styled confirmation page

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4f3136648832bb180ceaebcbe4f2b